### PR TITLE
Fix for docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,6 @@ web:
   links:
     - redis
   ports:
-    - ":80"
+    - "80:80"
 redis:
   image: redis


### PR DESCRIPTION
In Docker for Mac w/v1.12, you get the following error: 

$ docker-compose up
ERROR: The Compose file './docker-compose.yml' is invalid because:
web.ports is invalid: Invalid port ":80", should be [[remote_ip:]remote_port[-remote_port]:]port[/protocol]

This PR fixes it. 

cc @fermayo 
